### PR TITLE
Run Strat Error Fixed

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "react-scripts --openssl-legacy-provider start"
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
I got the Error message 'error:0308010C:digital envelope routines::unsupported' while trying to run this app, and I fixed it by adding --openssl-legacy-provider.